### PR TITLE
error fixed-HashMap to LinkedHashMap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,8 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.1.1</version>
                     <configuration>
-                        <source>8</source>
+			 <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+			 <source>8</source>
                     </configuration>
                     <executions>
                         <execution>

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
@@ -37,7 +37,7 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.text.ParseException;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -86,7 +86,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(3, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(3, 1);
             headerMap.put("alg", "ES256");
             headerMap.put("typ", "JWT");
             headerMap.put("kid", this.keyId);
@@ -129,7 +129,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(2, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(2, 1);
             headerMap.put("iss", this.issuer);
             headerMap.put("iat", this.issuedAt.getEpochSecond());
 


### PR DESCRIPTION
This PR addresses fixing a total of 11 flaky tests:

```
com.eatthepath.pushy.apns.ApnsClientTest#testSendNotification
com.eatthepath.pushy.apns.ApnsClientTest#testSendNotificationWithPushTypeHeader
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithEmptyPayload
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithCollapseId
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithExpirationDate
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithSpecifiedPriority
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithMissingPayload
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithOversizedPayload
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithWithExpiredAuthenticationToken
com.eatthepath.pushy.apns.auth.AuthenticationTokenTest#testVerifySignature
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithValidNotification.
```

Analysis for the test `testHandleNotificationWithSpecifiedPriority`: 
The function `AuthenticationTokenTest.testHeadersToMap()` examines whether the generated tokens are identical. However, the `AuthenticationTokenHeader.toMap()` method does not consistently produce the expected output, primarily because it lacks a predefined order and lacks determinism. This issue arises from the fact that the order of token chunks is not preserved due to the utilization of *HashedMap*. Consequently, the following tests may experience failures: `AuthenticationTokenHeader.toMap()` and `AuthenticationTokenClaims.toMap()`. 

This flakiness was found by using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. 

```
mvn -pl pushy edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithOversizedPayload
```

The fix was done in the line below:

https://github.com/Sujishark/pushy/blob/da5f8b97106cd41278b421ec63e4e76a7313bed9/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java#L132

**Environment:**

> Java: openjdk version "11.0.20.1"
> Maven: Apache Maven 3.6.3



This pull request aims to introduce a dependable sorting mechanism (HashMap to LinkedHashMap) for arranging the returned fields systematically.